### PR TITLE
feat(createdCheckout.ts): handle failed payment status in the webhook

### DIFF
--- a/src/routes/gRPC/data/query.ts
+++ b/src/routes/gRPC/data/query.ts
@@ -70,7 +70,7 @@ const TABLE_REGISTRY: Record<string, TableDef> = {
     fields: {
       proxy_link_id: { col: sessionsTable.proxy_link_id, cast: "uuid" },
       sessionId: { col: sessionsTable.sessionId, cast: "text" },
-      processed: { col: sessionsTable.processed, cast: "boolean" },
+      processed: { col: sessionsTable.processed, cast: "text" },
       userId: { col: sessionsTable.userId, cast: "uuid" },
       billedUpto: { col: sessionsTable.billed_upto, cast: "timestamptz" },
       createdAt: { col: sessionsTable.createdAt, cast: "timestamptz" },

--- a/src/routes/gRPC/data/query.ts
+++ b/src/routes/gRPC/data/query.ts
@@ -1,9 +1,5 @@
 import type { sendUnaryData } from "@grpc/grpc-js";
-import {
-  QueryRequest,
-  QueryResponse,
-  Row,
-} from "../../../gen/data/v1/data";
+import { QueryRequest, QueryResponse, Row } from "../../../gen/data/v1/data";
 import { dataQuerySchema, type DataQueryRequest } from "../../../zod/data";
 import { EventError } from "../../../errors/event";
 import { formatZodError } from "../../../utils/formatZodError";
@@ -72,7 +68,7 @@ const TABLE_REGISTRY: Record<string, TableDef> = {
     tableName: "sessions",
     table: sessionsTable,
     fields: {
-      id: { col: sessionsTable.id, cast: "uuid" },
+      proxy_link_id: { col: sessionsTable.proxy_link_id, cast: "uuid" },
       sessionId: { col: sessionsTable.sessionId, cast: "text" },
       processed: { col: sessionsTable.processed, cast: "boolean" },
       userId: { col: sessionsTable.userId, cast: "uuid" },

--- a/src/routes/http/createdCheckout.ts
+++ b/src/routes/http/createdCheckout.ts
@@ -5,8 +5,7 @@ import { handleAddPayment } from "../../storage/db/postgres/helpers/payments";
 import { getDodoClient } from "../gRPC/payment/paymentProvider.ts";
 import {
   getSessionByCheckoutId,
-  markSessionProcessed,
-  markSessionFailed,
+  updateSessionStatus,
 } from "../../storage/db/postgres/helpers/sessions";
 import { updateUserBilledTimestamp } from "../../storage/db/postgres/helpers/users";
 import { getPostgresDB } from "../../storage/db/postgres/db";
@@ -138,7 +137,12 @@ export async function handleDodoWebhook(
 
     if (webhookPayload.type === "payment.failed") {
       await executeInTransaction(db, "process failed", async (txn) => {
-        await markSessionFailed(checkout_session_id, txn);
+        const claimed = await updateSessionStatus(
+          checkout_session_id,
+          "failed",
+          txn
+        );
+        if (!claimed) return;
       });
 
       builder.setSuccess(200);
@@ -149,9 +153,14 @@ export async function handleDodoWebhook(
       const { userId, billed_upto, apiKeyId, mode } = session;
 
       await executeInTransaction(db, "process checkout", async (txn) => {
+        const claimed = await updateSessionStatus(
+          checkout_session_id,
+          "succeeded",
+          txn
+        );
+        if (!claimed) return;
         await updateUserBilledTimestamp(userId, billed_upto, txn);
         await handleAddPayment(userId, creditAmount, apiKeyId, mode, txn);
-        await markSessionProcessed(checkout_session_id, txn);
       });
 
       builder.setUser(userId);

--- a/src/routes/http/createdCheckout.ts
+++ b/src/routes/http/createdCheckout.ts
@@ -130,6 +130,10 @@ export async function handleDodoWebhook(
     }
 
     if (session.processed !== "pending") {
+      Sentry.captureMessage(
+        `Webhook received for session ${checkout_session_id} with non-pending status: ${session.processed}`,
+        { level: "warning" }
+      );
       return ignoredResponse(builder);
     }
 
@@ -141,7 +145,13 @@ export async function handleDodoWebhook(
         claimed = await updateSessionStatus(checkout_session_id, "failed", txn);
         if (!claimed) return;
       });
-      if (!claimed) return ignoredResponse(builder);
+      if (!claimed) {
+        Sentry.captureMessage(
+          `Session ${checkout_session_id} already processed (failed path), no rows updated`,
+          { level: "warning" }
+        );
+        return ignoredResponse(builder);
+      }
 
       builder.setSuccess(200);
     }
@@ -161,7 +171,13 @@ export async function handleDodoWebhook(
         await updateUserBilledTimestamp(userId, billed_upto, txn);
         await handleAddPayment(userId, creditAmount, apiKeyId, mode, txn);
       });
-      if (!claimed) return ignoredResponse(builder);
+      if (!claimed) {
+        Sentry.captureMessage(
+          `Session ${checkout_session_id} already processed (succeeded path), no rows updated`,
+          { level: "warning" }
+        );
+        return ignoredResponse(builder);
+      }
 
       builder.setUser(userId);
       builder.setPaymentContext({ creditAmount });

--- a/src/routes/http/createdCheckout.ts
+++ b/src/routes/http/createdCheckout.ts
@@ -136,14 +136,12 @@ export async function handleDodoWebhook(
     const db = getPostgresDB();
 
     if (webhookPayload.type === "payment.failed") {
+      let claimed: boolean = false;
       await executeInTransaction(db, "process failed", async (txn) => {
-        const claimed = await updateSessionStatus(
-          checkout_session_id,
-          "failed",
-          txn
-        );
+        claimed = await updateSessionStatus(checkout_session_id, "failed", txn);
         if (!claimed) return;
       });
+      if (!claimed) return ignoredResponse(builder);
 
       builder.setSuccess(200);
     }
@@ -151,9 +149,10 @@ export async function handleDodoWebhook(
     if (webhookPayload.type === "payment.succeeded") {
       const creditAmount = Math.round(webhookPayload.data.total_amount);
       const { userId, billed_upto, apiKeyId, mode } = session;
+      let claimed: boolean = false;
 
       await executeInTransaction(db, "process checkout", async (txn) => {
-        const claimed = await updateSessionStatus(
+        claimed = await updateSessionStatus(
           checkout_session_id,
           "succeeded",
           txn
@@ -162,6 +161,7 @@ export async function handleDodoWebhook(
         await updateUserBilledTimestamp(userId, billed_upto, txn);
         await handleAddPayment(userId, creditAmount, apiKeyId, mode, txn);
       });
+      if (!claimed) return ignoredResponse(builder);
 
       builder.setUser(userId);
       builder.setPaymentContext({ creditAmount });

--- a/src/routes/http/createdCheckout.ts
+++ b/src/routes/http/createdCheckout.ts
@@ -6,6 +6,7 @@ import { getDodoClient } from "../gRPC/payment/paymentProvider.ts";
 import {
   getSessionByCheckoutId,
   markSessionProcessed,
+  markSessionFailed,
 } from "../../storage/db/postgres/helpers/sessions";
 import { updateUserBilledTimestamp } from "../../storage/db/postgres/helpers/users";
 import { getPostgresDB } from "../../storage/db/postgres/db";
@@ -95,12 +96,14 @@ export async function handleDodoWebhook(
       );
     }
 
-    if (webhookPayload.type !== "payment.succeeded") {
+    if (
+      webhookPayload.type !== "payment.failed" &&
+      webhookPayload.type !== "payment.succeeded"
+    ) {
       return ignoredResponse(builder);
     }
 
     const { payment_id, checkout_session_id } = webhookPayload.data;
-    const creditAmount = Math.round(webhookPayload.data.total_amount);
 
     builder.setWebhookContext({
       webhookEvent: webhookPayload.type,
@@ -127,25 +130,35 @@ export async function handleDodoWebhook(
       );
     }
 
-    if (session.processed) {
+    if (session.processed !== "pending") {
       return ignoredResponse(builder);
     }
 
-    const userId = session.userId;
-    const billedUpto = session.billed_upto;
-    const apiKeyId = session.apiKeyId;
-    const mode = session.mode;
-
     const db = getPostgresDB();
-    await executeInTransaction(db, "process checkout", async (txn) => {
-      await updateUserBilledTimestamp(userId, billedUpto, txn);
-      await handleAddPayment(userId, creditAmount, apiKeyId, mode, txn);
-      await markSessionProcessed(checkout_session_id, txn);
-    });
 
-    builder.setUser(userId);
-    builder.setPaymentContext({ creditAmount });
-    builder.setSuccess(200);
+    if (webhookPayload.type === "payment.failed") {
+      await executeInTransaction(db, "process failed", async (txn) => {
+        await markSessionFailed(checkout_session_id, txn);
+      });
+
+      builder.setSuccess(200);
+    }
+
+    if (webhookPayload.type === "payment.succeeded") {
+      const creditAmount = Math.round(webhookPayload.data.total_amount);
+      const { userId, billed_upto, apiKeyId, mode } = session;
+
+      await executeInTransaction(db, "process checkout", async (txn) => {
+        await updateUserBilledTimestamp(userId, billed_upto, txn);
+        await handleAddPayment(userId, creditAmount, apiKeyId, mode, txn);
+        await markSessionProcessed(checkout_session_id, txn);
+      });
+
+      builder.setUser(userId);
+      builder.setPaymentContext({ creditAmount });
+      builder.setSuccess(200);
+    }
+
     return okResponse("Webhook processed successfully");
   } catch (error) {
     Sentry.captureException(error, {

--- a/src/storage/db/postgres/helpers/sessions.ts
+++ b/src/storage/db/postgres/helpers/sessions.ts
@@ -49,7 +49,7 @@ export async function checkIfExistingCheckoutLink(
       .limit(1)
       .for("update");
 
-    return existing?.id;
+    return existing?.proxy_link_id;
   } catch (e) {
     if (e instanceof Error && e.name === "StorageError") {
       throw e;
@@ -93,13 +93,13 @@ export async function handleAddSession(
         mode: mode,
         checkoutUrl: checkoutUrl,
       })
-      .returning({ id: sessionsTable.id });
+      .returning({ proxy_link_id: sessionsTable.proxy_link_id });
 
     if (!insertResult[0]) {
       throw StorageError.emptyResult("Session insert returned no record");
     }
 
-    const insertedId = insertResult[0].id;
+    const insertedId = insertResult[0].proxy_link_id;
     if (!insertedId) {
       throw StorageError.emptyResult("Session insert returned null id");
     }
@@ -159,7 +159,7 @@ export async function getCheckoutUrl(
     const [session] = await db
       .select({ checkoutUrl: sessionsTable.checkoutUrl })
       .from(sessionsTable)
-      .where(eq(sessionsTable.id, sessionId))
+      .where(eq(sessionsTable.proxy_link_id, sessionId))
       .limit(1);
 
     return session?.checkoutUrl;

--- a/src/storage/db/postgres/helpers/sessions.ts
+++ b/src/storage/db/postgres/helpers/sessions.ts
@@ -6,39 +6,25 @@ import { DateTime } from "luxon";
 import type { UserId } from "../../../../config/identifiers";
 import type { PgTransaction } from "drizzle-orm/pg-core";
 
-export async function markSessionProcessed(
+export async function updateSessionStatus(
   checkoutSessionId: string,
-  txn?: PgTransaction<any, any, any>
-): Promise<void> {
-  const db = txn ?? getPostgresDB();
-
+  status: "failed" | "succeeded",
+  txn: PgTransaction<any, any, any>
+): Promise<boolean> {
   try {
-    await db
+    const result = await txn
       .update(sessionsTable)
-      .set({ processed: "succeeded" })
-      .where(eq(sessionsTable.sessionId, checkoutSessionId));
+      .set({ processed: status })
+      .where(
+        and(
+          eq(sessionsTable.sessionId, checkoutSessionId),
+          eq(sessionsTable.processed, "pending")
+        )
+      );
+    return (result.count ?? 0) > 0;
   } catch (e) {
     throw StorageError.queryFailed(
-      "Failed to mark session as processed",
-      e instanceof Error ? e : new Error(String(e))
-    );
-  }
-}
-
-export async function markSessionFailed(
-  checkoutSessionId: string,
-  txn?: PgTransaction<any, any, any>
-): Promise<void> {
-  const db = txn ?? getPostgresDB();
-
-  try {
-    await db
-      .update(sessionsTable)
-      .set({ processed: "failed" })
-      .where(eq(sessionsTable.sessionId, checkoutSessionId));
-  } catch (e) {
-    throw StorageError.queryFailed(
-      "Failed to mark session as failed",
+      "Failed to update session status",
       e instanceof Error ? e : new Error(String(e))
     );
   }

--- a/src/storage/db/postgres/helpers/sessions.ts
+++ b/src/storage/db/postgres/helpers/sessions.ts
@@ -15,11 +15,30 @@ export async function markSessionProcessed(
   try {
     await db
       .update(sessionsTable)
-      .set({ processed: true })
+      .set({ processed: "succeeded" })
       .where(eq(sessionsTable.sessionId, checkoutSessionId));
   } catch (e) {
     throw StorageError.queryFailed(
       "Failed to mark session as processed",
+      e instanceof Error ? e : new Error(String(e))
+    );
+  }
+}
+
+export async function markSessionFailed(
+  checkoutSessionId: string,
+  txn?: PgTransaction<any, any, any>
+): Promise<void> {
+  const db = txn ?? getPostgresDB();
+
+  try {
+    await db
+      .update(sessionsTable)
+      .set({ processed: "failed" })
+      .where(eq(sessionsTable.sessionId, checkoutSessionId));
+  } catch (e) {
+    throw StorageError.queryFailed(
+      "Failed to mark session as failed",
       e instanceof Error ? e : new Error(String(e))
     );
   }
@@ -41,7 +60,7 @@ export async function checkIfExistingCheckoutLink(
       .where(
         and(
           eq(sessionsTable.userId, userId),
-          eq(sessionsTable.processed, false),
+          eq(sessionsTable.processed, "pending"),
           eq(sessionsTable.mode, mode),
           sql`${sessionsTable.createdAt} > ${DateTime.utc().minus({ hours: 24 }).toISO()}`
         )

--- a/src/storage/db/postgres/schema.ts
+++ b/src/storage/db/postgres/schema.ts
@@ -38,7 +38,7 @@ export const usersRelation = relations(usersTable, ({ many }) => ({
 export const sessionsTable = pgTable(
   "sessions",
   {
-    id: uuid("id").primaryKey().defaultRandom(),
+    proxy_link_id: uuid("id").primaryKey().defaultRandom(),
     sessionId: text("session_id").notNull().unique(),
     processed: boolean("processed").default(false),
     userId: USER_ID_CONFIG.dbType("user_id")

--- a/src/storage/db/postgres/schema.ts
+++ b/src/storage/db/postgres/schema.ts
@@ -38,9 +38,11 @@ export const usersRelation = relations(usersTable, ({ many }) => ({
 export const sessionsTable = pgTable(
   "sessions",
   {
-    proxy_link_id: uuid("id").primaryKey().defaultRandom(),
+    proxy_link_id: uuid("proxy_link_id").primaryKey().defaultRandom(),
     sessionId: text("session_id").notNull().unique(),
-    processed: boolean("processed").default(false),
+    processed: text("processed", { enum: ["pending", "failed", "succeeded"] })
+      .default("pending")
+      .notNull(),
     userId: USER_ID_CONFIG.dbType("user_id")
       .references(() => usersTable.id)
       .notNull(),
@@ -71,6 +73,10 @@ export const sessionRelations = relations(sessionsTable, ({ one }) => ({
   user: one(usersTable, {
     fields: [sessionsTable.userId],
     references: [usersTable.id],
+  }),
+  apiKey: one(apiKeysTable, {
+    fields: [sessionsTable.apiKeyId],
+    references: [apiKeysTable.id],
   }),
 }));
 


### PR DESCRIPTION
This pull request makes significant changes to how sessions are tracked and processed in the database and application logic, primarily by replacing the `id` field with `proxy_link_id` as the primary key and switching the `processed` field from a boolean to an enumerated status (`pending`, `failed`, `succeeded`). It also adds explicit handling for failed payment webhooks and updates related helper functions and database queries to use the new schema.

**Payment webhook handling:**

* Added explicit handling for `"payment.failed"` webhook events: marks the session as failed and returns a success response without further processing. (`src/routes/http/createdCheckout.ts`, `src/storage/db/postgres/helpers/sessions.ts`) [[1]](diffhunk://#diff-39754af191e2033637e1dfe4f43d01cfa6a888706954541cc2dc70f121b9a859L98-L103) [[2]](diffhunk://#diff-39754af191e2033637e1dfe4f43d01cfa6a888706954541cc2dc70f121b9a859L130-R161) [[3]](diffhunk://#diff-bb37732547ce97709eb057495609a0055592f8d3482f6e2a4a4983c92d83caa0R28-R46)

**Helper function updates:**

* Updated helper functions such as `markSessionProcessed`, `markSessionFailed`, `handleAddSession`, and `checkIfExistingCheckoutLink` to use the new `proxy_link_id` and `processed` enum values. (`src/storage/db/postgres/helpers/sessions.ts`) [[1]](diffhunk://#diff-bb37732547ce97709eb057495609a0055592f8d3482f6e2a4a4983c92d83caa0L18-R18) [[2]](diffhunk://#diff-bb37732547ce97709eb057495609a0055592f8d3482f6e2a4a4983c92d83caa0R28-R46) [[3]](diffhunk://#diff-bb37732547ce97709eb057495609a0055592f8d3482f6e2a4a4983c92d83caa0L96-R121) [[4]](diffhunk://#diff-bb37732547ce97709eb057495609a0055592f8d3482f6e2a4a4983c92d83caa0L44-R71)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook handling now only processes payment.failed and payment.succeeded events; successful payments update billing and record payments, failures mark sessions as failed.

* **Improvements**
  * Session state now uses explicit values: pending, failed, succeeded.
  * Checkout links and session lookups use a dedicated proxy link identifier for checkout references and resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScrawnDotDev/Scrawn/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->