### PR TITLE
fix: remove dev-only bind mount from server service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,9 +56,6 @@ services:
       CLICKHOUSE_URL: http://default:clickhouse@clickhouse:8123/scrawn
       NODE_ENV: production
       HMAC_SECRET: ${HMAC_SECRET}
-    volumes:
-      - .:/app
-      - /app/node_modules
 
   dashboard:
     image: scrawndotdev/dashboard:latest


### PR DESCRIPTION
The .:/app volume mount overrides the image's code with the host directory, making the server container unable to find its source files and drizzle config. Remove it since the image is self-contained.