### PR TITLE
feat: add Envoy proxy embedded in Docker image for unified gRPC/HTTP …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+FROM envoyproxy/envoy:tools-dev-86dd82f76a61e38a2de7b411c9da755cd9f67f4c AS envoy-bin
 FROM oven/bun:1
 
 WORKDIR /app
@@ -7,6 +8,12 @@ RUN bun install --frozen-lockfile
 
 COPY . .
 
-EXPOSE 8070 8069
+COPY --from=envoy-bin /usr/local/bin/envoy /usr/local/bin/envoy
 
-CMD ["sh", "-c", "for i in 1 2 3 4 5; do bunx drizzle-kit push --force && break; sleep 3; done && bun run src/server.ts"]
+COPY envoy/envoy.yaml /etc/envoy/envoy.yaml
+COPY envoy/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8060
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Usage:
 #   docker compose up                                    # db only
 #   docker compose --profile clickhouse up               # db + clickhouse
-#   docker compose --profile production up               # db + server + dashboard
+#   docker compose --profile production up               # db + server (with envoy) + dashboard
 #   docker compose --profile production --profile clickhouse up  # all services
 services:
   db:
@@ -48,8 +48,7 @@ services:
     image: scrawndotdev/scrawn:latest
     restart: unless-stopped
     ports:
-      - "8070:8070"
-      - "8069:8069"
+      - "8060:8060"
     depends_on:
       db:
         condition: service_healthy

--- a/envoy/entrypoint.sh
+++ b/envoy/entrypoint.sh
@@ -4,8 +4,14 @@ set -e
 envoy --mode validate -c /etc/envoy/envoy.yaml
 
 envoy -c /etc/envoy/envoy.yaml --log-level "${ENVOY_LOG_LEVEL:-warning}" &
+ENVOY_PID=$!
 
 sleep 2
+
+if ! kill -0 "$ENVOY_PID" 2>/dev/null; then
+  echo "Envoy failed to start" >&2
+  exit 1
+fi
 
 for i in 1 2 3 4 5; do
   bunx drizzle-kit push --force && break

--- a/envoy/entrypoint.sh
+++ b/envoy/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+envoy --mode validate -c /etc/envoy/envoy.yaml
+
+envoy -c /etc/envoy/envoy.yaml --log-level "${ENVOY_LOG_LEVEL:-warning}" &
+
+sleep 2
+
+for i in 1 2 3 4 5; do
+  bunx drizzle-kit push --force && break
+  sleep 3
+done
+
+exec bun run src/server.ts

--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -38,6 +38,7 @@ static_resources:
     - name: grpc_backend
       type: STRICT_DNS
       lb_policy: ROUND_ROBIN
+      connect_timeout: 5s
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -55,6 +56,7 @@ static_resources:
     - name: http_backend
       type: STRICT_DNS
       lb_policy: ROUND_ROBIN
+      connect_timeout: 5s
       load_assignment:
         cluster_name: http_backend
         endpoints:

--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -1,0 +1,66 @@
+static_resources:
+  listeners:
+    - name: main_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8060
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                codec_type: AUTO
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: backend
+                      domains: ["*"]
+                      routes:
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: content-type
+                                string_match:
+                                  prefix: application/grpc
+                          route:
+                            cluster: grpc_backend
+                        - match:
+                            prefix: "/"
+                          route:
+                            cluster: http_backend
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: grpc_backend
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: grpc_backend
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8069
+    - name: http_backend
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: http_backend
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: 127.0.0.1
+                      port_value: 8070


### PR DESCRIPTION
…entry point

- Multi-stage Dockerfile extracts envoy binary from envoyproxy/envoy:tools-dev-...
- Envoy listens on :8060, routes gRPC (content-type: application/grpc*) to localhost:8069 and everything else to localhost:8070
- server port mapping in docker-compose.yml changed from 8069/8070 to 8060