### PR TITLE
fix(createCheckoutLink.ts): fix multiple checkout links being generated

### DIFF
--- a/src/routes/gRPC/payment/createCheckoutLink.ts
+++ b/src/routes/gRPC/payment/createCheckoutLink.ts
@@ -30,6 +30,9 @@ import { handleAddSession } from "../../../storage/db/postgres/helpers/sessions"
 import { type ContextUnaryCall } from "../../../interface/types/context.ts";
 import { getPostgresDB } from "../../../storage/db/postgres/db";
 import { checkIfExistingCheckoutLink } from "../../../storage/db/postgres/helpers/sessions";
+import { ensureUserExists } from "../../../storage/db/postgres/helpers/users";
+import { usersTable } from "../../../storage/db/postgres/schema";
+import { eq } from "drizzle-orm";
 
 export async function createCheckoutLink(
   call: ContextUnaryCall<CreateCheckoutLinkRequest, CreateCheckoutLinkResponse>,
@@ -89,6 +92,14 @@ export async function createCheckoutLink(
       db,
       "create checkout link",
       async (txn) => {
+        await ensureUserExists(validatedData.userId, txn);
+
+        await txn
+          .select({ id: usersTable.id })
+          .from(usersTable)
+          .where(eq(usersTable.id, validatedData.userId))
+          .for("update");
+
         const existingId = await checkIfExistingCheckoutLink(
           txn,
           validatedData.userId,


### PR DESCRIPTION
This pull request enhances the `createCheckoutLink` gRPC route by adding checks to ensure that the user exists in the database and by locking the user row during the transaction to prevent race conditions. These changes improve the reliability and consistency of the checkout link creation process.

**User existence validation and transaction safety improvements:**

* Added a call to `ensureUserExists` before proceeding with checkout link creation to guarantee the user is present in the database.
* Introduced a `SELECT ... FOR UPDATE` statement on the `usersTable` to lock the user row during the transaction, preventing concurrent modifications and potential race conditions.