### PR TITLE
feat(src): implementing multiple projects layer

### DIFF
--- a/src/context/auth.ts
+++ b/src/context/auth.ts
@@ -6,4 +6,5 @@ export interface AuthContext {
   apiKeyId: string;
   role: ApiKeyRole;
   mode: "production" | "test" | null;
+  projectId: string;
 }

--- a/src/interceptors/auth.ts
+++ b/src/interceptors/auth.ts
@@ -18,6 +18,7 @@ import { getPostgresDB } from "../storage/db/postgres/db";
 import {
   apiKeysTable,
   webhookEndpointsTable,
+  projectsTable,
 } from "../storage/db/postgres/schema";
 import { eq, and, isNull } from "drizzle-orm";
 import { hashAPIKey } from "../utils/hashAPIKey";
@@ -46,6 +47,11 @@ const webhookEndpointCache = Cache.getStore<string, boolean>(
   }
 );
 
+const projectExistsCache = Cache.getStore<string, boolean>("projects", {
+  max: 500,
+  ttlMs: 5 * 60 * 1000,
+});
+
 /**
  * Invalidate the cached webhook endpoint existence for an API key.
  * Must be called after upserting or deleting a webhook endpoint so
@@ -53,6 +59,22 @@ const webhookEndpointCache = Cache.getStore<string, boolean>(
  */
 export function invalidateWebhookEndpointCache(apiKeyId: string): void {
   webhookEndpointCache.delete(apiKeyId);
+}
+
+async function checkProjectExists(projectId: string): Promise<boolean> {
+  const cached = projectExistsCache.get(projectId);
+  if (cached !== undefined) return cached;
+
+  const db = getPostgresDB();
+  const [row] = await db
+    .select({ id: projectsTable.id })
+    .from(projectsTable)
+    .where(eq(projectsTable.id, projectId))
+    .limit(1);
+
+  const exists = !!row;
+  projectExistsCache.set(projectId, exists);
+  return exists;
 }
 
 interface GrpcCallContext {
@@ -107,7 +129,7 @@ async function checkWebhookEndpoint(apiKeyId: string): Promise<boolean> {
 }
 
 /**
- * Auth interceptor for gRPC — validates API key, extracts role, sets context.
+ * Auth interceptor for gRPC — validates API key, extracts role, reads project ID, sets context.
  */
 export function authInterceptor<Req, Res>(
   methodPath: string,
@@ -148,11 +170,69 @@ export function authInterceptor<Req, Res>(
       return callback?.(AuthError.invalidAPIKey("Invalid API key format"));
     }
 
+    const projectId = call.metadata.get("x-project-id")?.[0] as
+      | string
+      | undefined;
+
+    if (!projectId) {
+      return callback?.(
+        AuthError.permissionDenied(
+          "Missing required 'x-project-id' metadata header"
+        )
+      );
+    }
+
     const mode = getModeForRole(role);
     const apiKeyHash = hashAPIKey(apiKey);
 
     const needsWebhook =
       role !== "dashboard" && WEBHOOK_REQUIRED_PATHS.includes(fullPath);
+
+    const resolveWithProject = (
+      apiKeyId: string,
+      apiKeyRole: ApiKeyRole,
+      apiKeyMode: "production" | "test" | null
+    ) =>
+      checkProjectExists(projectId)
+        .then((exists) => {
+          if (!exists) {
+            return callback?.(
+              AuthError.permissionDenied(`Project '${projectId}' not found`)
+            );
+          }
+
+          call[apiKeyContextKey] = {
+            apiKeyId,
+            role: apiKeyRole,
+            mode: apiKeyMode,
+            projectId,
+          };
+          wideEventBuilder?.setAuth(apiKeyId, true);
+
+          if (needsWebhook) {
+            return checkWebhookEndpoint(apiKeyId)
+              .then((hasEndpoint) => {
+                if (!hasEndpoint) {
+                  return callback?.(
+                    AuthError.permissionDenied(
+                      "A webhook endpoint must be configured before using this API key. " +
+                        "Register one via POST /api/v1/internals/webhook-endpoint"
+                    )
+                  );
+                }
+                return handler(call, callback);
+              })
+              .catch((error) => callback?.(error));
+          }
+
+          return handler(call, callback);
+        })
+        .catch((error) =>
+          callback?.({
+            code: grpcStatus.UNAVAILABLE,
+            details: error instanceof Error ? error.message : String(error),
+          })
+        );
 
     const cached = apiKeyCache.get(apiKeyHash);
     if (cached) {
@@ -163,30 +243,7 @@ export function authInterceptor<Req, Res>(
           )
         );
       }
-      call[apiKeyContextKey] = {
-        apiKeyId: cached.id,
-        role: cached.role,
-        mode: cached.mode,
-      };
-      wideEventBuilder?.setAuth(cached.id, true);
-
-      if (needsWebhook) {
-        return checkWebhookEndpoint(cached.id)
-          .then((hasEndpoint) => {
-            if (!hasEndpoint) {
-              return callback?.(
-                AuthError.permissionDenied(
-                  "A webhook endpoint must be configured before using this API key. " +
-                    "Register one via POST /api/v1/internals/webhook-endpoint"
-                )
-              );
-            }
-            return handler(call, callback);
-          })
-          .catch((error) => callback?.(error));
-      }
-
-      return handler(call, callback);
+      return resolveWithProject(cached.id, cached.role, cached.mode);
     }
 
     return lookupApiKey(apiKeyHash)
@@ -223,35 +280,11 @@ export function authInterceptor<Req, Res>(
           expiresAt: apiKeyRecord.expiresAt,
         });
 
-        call[apiKeyContextKey] = {
-          apiKeyId: apiKeyRecord.id,
-          role: apiKeyRecord.role as ApiKeyRole,
-          mode: recordMode,
-        };
-        wideEventBuilder?.setAuth(apiKeyRecord.id, false);
-
-        if (needsWebhook) {
-          return checkWebhookEndpoint(apiKeyRecord.id)
-            .then((hasEndpoint) => {
-              if (!hasEndpoint) {
-                return callback?.(
-                  AuthError.permissionDenied(
-                    "A webhook endpoint must be configured before using this API key. " +
-                      "Register one via POST /api/v1/internals/webhook-endpoint"
-                  )
-                );
-              }
-              return handler(call, callback);
-            })
-            .catch((error) => {
-              return callback?.({
-                code: grpcStatus.UNAVAILABLE,
-                details: error instanceof Error ? error.message : String(error),
-              });
-            });
-        }
-
-        return handler(call, callback);
+        return resolveWithProject(
+          apiKeyRecord.id,
+          apiKeyRecord.role as ApiKeyRole,
+          recordMode
+        );
       })
       .catch((error) => {
         return callback?.({

--- a/src/routes/gRPC/payment/createCheckoutLink.ts
+++ b/src/routes/gRPC/payment/createCheckoutLink.ts
@@ -64,7 +64,7 @@ export async function createCheckoutLink(
 
     const mode = auth.mode;
 
-    const config = await getPaymentProviderConfig(mode);
+    const config = await getPaymentProviderConfig(mode, auth.projectId);
     const validatedData = validateRequest(req);
     wideEventBuilder?.setUser(validatedData.userId);
 
@@ -85,7 +85,8 @@ export async function createCheckoutLink(
       validatedData.userId,
       auth.apiKeyId,
       beforeTimestamp,
-      mode
+      mode,
+      auth.projectId
     );
 
     const checkoutLink = await executeInTransaction(
@@ -103,7 +104,8 @@ export async function createCheckoutLink(
         const existingId = await checkIfExistingCheckoutLink(
           txn,
           validatedData.userId,
-          mode
+          mode,
+          auth.projectId
         );
 
         if (existingId) {
@@ -118,6 +120,7 @@ export async function createCheckoutLink(
           auth.apiKeyId,
           mode,
           checkoutResult.checkoutUrl,
+          auth.projectId,
           txn
         );
         wideEventBuilder?.setPaymentContext({ sessionId: sessionResult.id });
@@ -169,7 +172,8 @@ async function createCheckoutSession(
   userId: string,
   apiKeyId: string,
   beforeTimestamp: DateTime,
-  mode: "test" | "production"
+  mode: "test" | "production",
+  projectId: string
 ): Promise<CheckoutResult> {
   const params: CheckoutParams = {
     customPrice,
@@ -177,7 +181,12 @@ async function createCheckoutSession(
     apiKeyId,
   };
 
-  const checkoutResult = await createProviderCheckout(config, params, mode);
+  const checkoutResult = await createProviderCheckout(
+    config,
+    params,
+    mode,
+    projectId
+  );
 
   if (
     !checkoutResult.checkoutUrl ||

--- a/src/routes/gRPC/payment/paymentProvider.ts
+++ b/src/routes/gRPC/payment/paymentProvider.ts
@@ -3,60 +3,52 @@ import { PaymentError } from "../../../errors/payment";
 import { getMetadata } from "../../../storage/db/postgres/helpers/metadata";
 import { decrypt } from "../../../utils/encryptMetadata.ts";
 
-let liveClient: DodoPayments | null = null;
-let testClient: DodoPayments | null = null;
+// Per-project client caches: projectId → client
+const liveClients = new Map<string, DodoPayments>();
+const testClients = new Map<string, DodoPayments>();
 
-function clearClients(): void {
-  liveClient = null;
-  testClient = null;
+export function clearClients(projectId?: string): void {
+  if (projectId) {
+    liveClients.delete(projectId);
+    testClients.delete(projectId);
+  } else {
+    liveClients.clear();
+    testClients.clear();
+  }
 }
 
 export async function getDodoClient(
-  mode?: "test" | "production"
+  mode: "test" | "production",
+  projectId: string
 ): Promise<DodoPayments> {
-  if (!mode) {
-    mode = process.env.NODE_ENV === "production" ? "production" : "test";
-  }
+  const cache = mode === "production" ? liveClients : testClients;
+  const cached = cache.get(projectId);
+  if (cached) return cached;
 
-  if (mode === "production") {
-    if (liveClient) return liveClient;
+  const metadata = await getMetadata(projectId);
+  const apiKey =
+    mode === "production"
+      ? metadata?.dodo_live_api_key
+      : metadata?.dodo_test_api_key;
 
-    const metadata = await getMetadata();
-    const apiKey = metadata?.dodo_live_api_key;
-    if (!apiKey) {
-      throw PaymentError.missingApiKey();
-    }
-
-    liveClient = new DodoPayments({
-      bearerToken: decrypt(apiKey),
-      environment: "live_mode",
-      webhookKey: metadata?.dodo_live_webhook_secret
-        ? decrypt(metadata.dodo_live_webhook_secret)
-        : undefined,
-    });
-    return liveClient;
-  }
-
-  if (testClient) return testClient;
-
-  const metadata = await getMetadata();
-  const apiKey = metadata?.dodo_test_api_key;
   if (!apiKey) {
     throw PaymentError.missingApiKey();
   }
 
-  testClient = new DodoPayments({
-    bearerToken: decrypt(apiKey),
-    environment: "test_mode",
-    webhookKey: metadata?.dodo_test_webhook_secret
-      ? decrypt(metadata.dodo_test_webhook_secret)
-      : undefined,
-  });
-  return testClient;
-}
+  const webhookSecret =
+    mode === "production"
+      ? metadata?.dodo_live_webhook_secret
+      : metadata?.dodo_test_webhook_secret;
 
-// Re-export for callers who need to invalidate cached clients after onboarding updates
-export { clearClients };
+  const client = new DodoPayments({
+    bearerToken: decrypt(apiKey),
+    environment: mode === "production" ? "live_mode" : "test_mode",
+    webhookKey: webhookSecret ? decrypt(webhookSecret) : undefined,
+  });
+
+  cache.set(projectId, client);
+  return client;
+}
 
 export interface PaymentProviderConfig {
   productId: string;
@@ -76,13 +68,10 @@ export interface CheckoutResult {
 }
 
 export async function getPaymentProviderConfig(
-  mode: "test" | "production"
+  mode: "test" | "production",
+  projectId: string
 ): Promise<PaymentProviderConfig> {
-  if (!mode) {
-    mode = process.env.NODE_ENV === "production" ? "production" : "test";
-  }
-
-  const metadata = await getMetadata();
+  const metadata = await getMetadata(projectId);
 
   if (!metadata) {
     throw PaymentError.missingMetadata();
@@ -90,9 +79,9 @@ export async function getPaymentProviderConfig(
 
   const productId =
     mode === "production"
-      ? metadata?.dodo_live_product_id
-      : metadata?.dodo_test_product_id;
-  const returnUrl = metadata?.redirect_url ?? null;
+      ? metadata.dodo_live_product_id
+      : metadata.dodo_test_product_id;
+  const returnUrl = metadata.redirect_url ?? null;
 
   if (!productId) {
     throw PaymentError.missingProductId();
@@ -104,9 +93,10 @@ export async function getPaymentProviderConfig(
 export async function createProviderCheckout(
   config: PaymentProviderConfig,
   params: CheckoutParams,
-  mode: "test" | "production"
+  mode: "test" | "production",
+  projectId: string
 ): Promise<CheckoutResult> {
-  const client = await getDodoClient(mode);
+  const client = await getDodoClient(mode, projectId);
 
   const session = await client.checkoutSessions.create({
     product_cart: [

--- a/src/routes/http/api/onboarding.ts
+++ b/src/routes/http/api/onboarding.ts
@@ -2,25 +2,40 @@ import type { FastifyRequest, FastifyReply } from "fastify";
 import * as Sentry from "@sentry/bun";
 import { ZodError } from "zod";
 import DodoPayments from "dodopayments";
-import { onboardingSchema } from "../../../zod/internals.ts";
 import {
   createWideEventBuilder,
   generateRequestId,
 } from "../../../context/requestContext.ts";
 import { logger } from "../../../errors/logger.ts";
-import { AuthError } from "../../../errors/auth";
+import { AuthError } from "../../../errors/auth.ts";
 import { authenticateHttpApiKey } from "../../../utils/authenticateHttpApiKey.ts";
+import {
+  createProject,
+  listProjects,
+  getProject,
+} from "../../../storage/db/postgres/helpers/projects.ts";
 import {
   upsertMetadata,
   getMetadata,
 } from "../../../storage/db/postgres/helpers/metadata.ts";
 import { clearClients } from "../../gRPC/payment/paymentProvider.ts";
 import { encrypt, decrypt } from "../../../utils/encryptMetadata.ts";
+import { z } from "zod";
 
-export async function handleOnboarding(
+const createProjectSchema = z.object({
+  name: z.string().min(1, "Project name is required"),
+  dodoLiveApiKey: z.string().min(1),
+  dodoTestApiKey: z.string().min(1),
+  dodoLiveProductId: z.string().min(1),
+  dodoTestProductId: z.string().min(1),
+  currency: z.string().min(1),
+  redirectUrl: z.string().url(),
+});
+
+export async function handleCreateProject(
   request: FastifyRequest,
   reply: FastifyReply
-): Promise<Record<string, never>> {
+): Promise<Record<string, unknown>> {
   const builder = createWideEventBuilder(
     generateRequestId(),
     request.method,
@@ -32,7 +47,7 @@ export async function handleOnboarding(
     await authenticateHttpApiKey(authHeader);
 
     const body = await request.body;
-    const validated = onboardingSchema.parse(body);
+    const validated = createProjectSchema.parse(body);
 
     const appUrl = process.env.APP_URL;
     if (!appUrl) {
@@ -41,8 +56,11 @@ export async function handleOnboarding(
         message: "APP_URL environment variable is not set",
       });
       reply.code(500);
-      return {};
+      return { error: "APP_URL not set" };
     }
+
+    const projectResult = await createProject(validated.name);
+    const projectId = projectResult.id;
 
     const liveClient = new DodoPayments({
       bearerToken: validated.dodoLiveApiKey,
@@ -57,16 +75,16 @@ export async function handleOnboarding(
     let testSecret: string;
     try {
       const liveWebhook = await liveClient.webhooks.create({
-        url: `${appUrl}/webhooks/payment/createdCheckout?mode=production`,
-        description: "Scrawn live payment webhook",
+        url: `${appUrl}/webhooks/payment/createdCheckout/${projectId}?mode=production`,
+        description: `Scrawn live payment webhook for ${validated.name}`,
         filter_types: ["payment.succeeded", "payment.failed"],
       });
       liveSecret = (await liveClient.webhooks.retrieveSecret(liveWebhook.id))
         .secret;
 
       const testWebhook = await testClient.webhooks.create({
-        url: `${appUrl}/webhooks/payment/createdCheckout?mode=test`,
-        description: "Scrawn test payment webhook",
+        url: `${appUrl}/webhooks/payment/createdCheckout/${projectId}?mode=test`,
+        description: `Scrawn test payment webhook for ${validated.name}`,
         filter_types: ["payment.succeeded", "payment.failed"],
       });
       testSecret = (await testClient.webhooks.retrieveSecret(testWebhook.id))
@@ -74,17 +92,18 @@ export async function handleOnboarding(
     } catch (error) {
       const errMsg = error instanceof Error ? error.message : String(error);
       Sentry.captureException(error, {
-        extra: { context: "dodo webhook registration during onboarding" },
+        extra: { context: "dodo webhook registration for project" },
       });
       builder.setError(400, {
         type: "DodoApiError",
         message: `Failed to register webhook with Dodo: ${errMsg}`,
       });
       reply.code(400);
-      return {};
+      return { error: `Failed to register webhook with Dodo: ${errMsg}` };
     }
 
     await upsertMetadata({
+      projectId,
       dodo_live_api_key: encrypt(validated.dodoLiveApiKey),
       dodo_test_api_key: encrypt(validated.dodoTestApiKey),
       dodo_live_product_id: validated.dodoLiveProductId,
@@ -95,15 +114,15 @@ export async function handleOnboarding(
       redirect_url: validated.redirectUrl,
     });
 
-    clearClients();
+    clearClients(projectId);
 
     builder.setSuccess(200);
 
     reply.code(201);
-    return {};
+    return { id: projectId };
   } catch (error) {
     Sentry.captureException(error, {
-      extra: { context: "onboarding route handler" },
+      extra: { context: "create project handler" },
     });
 
     if (error instanceof AuthError) {
@@ -112,7 +131,7 @@ export async function handleOnboarding(
         message: error.message,
       });
       reply.code(401);
-      return {};
+      return { error: error.message };
     }
 
     if (error instanceof ZodError) {
@@ -124,7 +143,7 @@ export async function handleOnboarding(
         message: issues,
       });
       reply.code(400);
-      return {};
+      return { error: issues };
     }
 
     const err = error instanceof Error ? error : new Error(String(error));
@@ -133,19 +152,13 @@ export async function handleOnboarding(
       message: err.message,
     });
     reply.code(500);
-    return {};
+    return { error: err.message };
   } finally {
     logger.emit(builder.build());
   }
 }
 
-function maskApiKey(key: string | null | undefined): string | null {
-  if (!key) return null;
-  if (key.length <= 16) return "****";
-  return key.slice(0, 4) + "****" + key.slice(-4);
-}
-
-export async function handleGetConfig(
+export async function handleListProjects(
   request: FastifyRequest,
   reply: FastifyReply
 ): Promise<Record<string, unknown>> {
@@ -159,17 +172,80 @@ export async function handleGetConfig(
     const authHeader = request.headers.authorization;
     await authenticateHttpApiKey(authHeader);
 
-    const metadata = await getMetadata();
+    const projects = await listProjects();
+
+    builder.setSuccess(200);
+    reply.code(200);
+    return { projects };
+  } catch (error) {
+    Sentry.captureException(error, {
+      extra: { context: "list projects handler" },
+    });
+
+    if (error instanceof AuthError) {
+      builder.setError(401, {
+        type: error.type,
+        message: error.message,
+      });
+      reply.code(401);
+      return { error: error.message };
+    }
+
+    builder.setError(500, {
+      type: "InternalError",
+      message: "Failed to list projects",
+    });
+    reply.code(500);
+    return { error: "Internal server error" };
+  } finally {
+    logger.emit(builder.build());
+  }
+}
+
+function maskApiKey(key: string | null | undefined): string | null {
+  if (!key) return null;
+  if (key.length <= 16) return "****";
+  return key.slice(0, 4) + "****" + key.slice(-4);
+}
+
+export async function handleGetProject(
+  request: FastifyRequest<{ Params: { projectId: string } }>,
+  reply: FastifyReply
+): Promise<Record<string, unknown>> {
+  const builder = createWideEventBuilder(
+    generateRequestId(),
+    request.method,
+    request.url
+  );
+
+  try {
+    const authHeader = request.headers.authorization;
+    await authenticateHttpApiKey(authHeader);
+
+    const projectId = request.params.projectId;
+    if (!projectId) {
+      reply.code(400);
+      return { error: "Missing projectId" };
+    }
+
+    const project = await getProject(projectId);
+    if (!project) {
+      reply.code(404);
+      return { error: "Project not found" };
+    }
+
+    const metadata = await getMetadata(projectId);
 
     if (!metadata) {
       builder.setSuccess(200);
       reply.code(200);
-      return { configured: false };
+      return { project, configured: false };
     }
 
     builder.setSuccess(200);
     reply.code(200);
     return {
+      project,
       configured: true,
       dodo_live_api_key: maskApiKey(decrypt(metadata.dodo_live_api_key)),
       dodo_test_api_key: maskApiKey(decrypt(metadata.dodo_test_api_key)),
@@ -186,7 +262,7 @@ export async function handleGetConfig(
     };
   } catch (error) {
     Sentry.captureException(error, {
-      extra: { context: "get config handler" },
+      extra: { context: "get project handler" },
     });
 
     if (error instanceof AuthError) {
@@ -200,7 +276,7 @@ export async function handleGetConfig(
 
     builder.setError(500, {
       type: "InternalError",
-      message: "Failed to read config",
+      message: "Failed to read project config",
     });
     reply.code(500);
     return { error: "Internal server error" };

--- a/src/routes/http/api/registerApiRoutes.ts
+++ b/src/routes/http/api/registerApiRoutes.ts
@@ -1,5 +1,9 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
-import { handleOnboarding, handleGetConfig } from "./onboarding.ts";
+import {
+  handleCreateProject,
+  handleListProjects,
+  handleGetProject,
+} from "./onBoarding.ts";
 import { handleListTags, handleCreateTag, handleDeleteTag } from "./tags.ts";
 import {
   handleListExpressions,
@@ -23,18 +27,28 @@ import { handleListDeliveries } from "./webhookDeliveries.ts";
 export async function registerApiRoutes(
   server: ReturnType<(typeof import("fastify"))["fastify"]>
 ): Promise<void> {
-  // Onboarding / config
+  // Projects
   server.post(
-    "/api/v1/internals/onboarding",
+    "/api/v1/internals/projects",
     async (request: FastifyRequest, reply: FastifyReply) => {
-      return handleOnboarding(request, reply);
+      return handleCreateProject(request, reply);
     }
   );
 
   server.get(
-    "/api/v1/internals/config",
+    "/api/v1/internals/projects",
     async (request: FastifyRequest, reply: FastifyReply) => {
-      return handleGetConfig(request, reply);
+      return handleListProjects(request, reply);
+    }
+  );
+
+  server.get(
+    "/api/v1/internals/projects/:projectId",
+    async (
+      request: FastifyRequest<{ Params: { projectId: string } }>,
+      reply: FastifyReply
+    ) => {
+      return handleGetProject(request, reply);
     }
   );
 

--- a/src/routes/http/createdCheckout.ts
+++ b/src/routes/http/createdCheckout.ts
@@ -72,11 +72,13 @@ export async function handleDodoWebhook(
   timestamp: string | undefined,
   webhookId: string | undefined,
   mode: "production" | "test",
+  projectId: string,
   builder: WideEventBuilder
 ): Promise<WebhookResponse> {
   try {
     const client = await getDodoClient(
-      mode === "production" ? "production" : "test"
+      mode === "production" ? "production" : "test",
+      projectId
     );
     const headers = buildWebhookHeaders(signature, timestamp, webhookId);
     const webhookPayload = unwrapWebhookPayload(client, rawBody, headers);
@@ -197,6 +199,7 @@ export async function handleDodoWebhook(
           apiKeyId,
           mode,
           session.proxy_link_id,
+          session.projectId,
           txn
         );
       });

--- a/src/routes/http/registerWebhookRoutes.ts
+++ b/src/routes/http/registerWebhookRoutes.ts
@@ -21,10 +21,10 @@ export async function registerWebhookRoutes(
   server: ReturnType<(typeof import("fastify"))["fastify"]>
 ): Promise<void> {
   server.post(
-    "/webhooks/payment/createdCheckout",
+    "/webhooks/payment/createdCheckout/:projectId",
     { config: { rawBody: true } },
     async (
-      request: FastifyRequest & {
+      request: FastifyRequest<{ Params: { projectId: string } }> & {
         rawBody?: string;
       },
       reply: FastifyReply
@@ -36,6 +36,16 @@ export async function registerWebhookRoutes(
       );
 
       try {
+        const projectId = request.params.projectId;
+        if (!projectId) {
+          builder.setError(400, {
+            type: "ValidationError",
+            message: "Missing 'projectId' path parameter.",
+          });
+          reply.code(400);
+          return { error: "Missing projectId path parameter" };
+        }
+
         const mode = (request.query as Record<string, string>)?.mode;
         if (mode !== "production" && mode !== "test") {
           builder.setError(400, {
@@ -72,6 +82,7 @@ export async function registerWebhookRoutes(
           timestamp,
           webhookId,
           mode,
+          projectId,
           builder
         );
 

--- a/src/storage/adapter/clickhouse/handlers/addAiTokenUsage.ts
+++ b/src/storage/adapter/clickhouse/handlers/addAiTokenUsage.ts
@@ -139,6 +139,7 @@ function buildAiTokenInsertRows(
       idempotency_key: aggEvent.idempotencyKey,
       user_id: aggEvent.userId,
       api_key_id: auth.apiKeyId,
+      project_id: auth.projectId,
       mode: auth.mode,
       reported_timestamp: aggEvent.reported_timestamp,
       ingested_timestamp: now,

--- a/src/storage/adapter/clickhouse/handlers/addBasicUsage.ts
+++ b/src/storage/adapter/clickhouse/handlers/addBasicUsage.ts
@@ -41,6 +41,7 @@ export async function handleAddBasicUsage(
           idempotency_key: event_data.idempotencyKey,
           user_id: event_data.userId,
           api_key_id: auth.apiKeyId,
+          project_id: auth.projectId,
           mode: auth.mode,
           reported_timestamp: reportedTimestamp,
           ingested_timestamp: toClickHouseDateTime(DateTime.utc()),

--- a/src/storage/adapter/clickhouse/handlers/priceRequestAiTokenUsage.ts
+++ b/src/storage/adapter/clickhouse/handlers/priceRequestAiTokenUsage.ts
@@ -5,8 +5,8 @@ import { runClickHousePriceQuery } from "../utils";
 
 const VALUE_EXPR =
   "JSONExtractInt(metrics, 'debit_amount', 'input') + JSONExtractInt(metrics, 'debit_amount', 'input_cache') + JSONExtractInt(metrics, 'debit_amount', 'output')";
-const BASE_QUERY = `SELECT sum(${VALUE_EXPR}) as total FROM ai_token_usage_events WHERE user_id = {userId:String} AND mode = {mode:String} AND reported_timestamp < {before:DateTime64(3, 'UTC')}`;
-const WINDOW_QUERY = `SELECT sum(${VALUE_EXPR}) as total FROM ai_token_usage_events WHERE user_id = {userId:String} AND mode = {mode:String} AND reported_timestamp > {lastBilled:DateTime64(3, 'UTC')} AND reported_timestamp < {before:DateTime64(3, 'UTC')}`;
+const BASE_QUERY = `SELECT sum(${VALUE_EXPR}) as total FROM ai_token_usage_events WHERE user_id = {userId:String} AND mode = {mode:String} AND project_id = {projectId:String} AND reported_timestamp < {before:DateTime64(3, 'UTC')}`;
+const WINDOW_QUERY = `SELECT sum(${VALUE_EXPR}) as total FROM ai_token_usage_events WHERE user_id = {userId:String} AND mode = {mode:String} AND project_id = {projectId:String} AND reported_timestamp > {lastBilled:DateTime64(3, 'UTC')} AND reported_timestamp < {before:DateTime64(3, 'UTC')}`;
 
 export async function handlePriceRequestAiTokenUsage(
   userId: UserId,

--- a/src/storage/adapter/clickhouse/handlers/priceRequestBasicUsage.ts
+++ b/src/storage/adapter/clickhouse/handlers/priceRequestBasicUsage.ts
@@ -4,9 +4,9 @@ import type { AuthContext } from "../../../../context/auth";
 import { runClickHousePriceQuery } from "../utils";
 
 const BASE_QUERY =
-  "SELECT sum(debit_amount) as total FROM basic_usage_events WHERE user_id = {userId:String} AND mode = {mode:String} AND reported_timestamp < {before:DateTime64(3, 'UTC')}";
+  "SELECT sum(debit_amount) as total FROM basic_usage_events WHERE user_id = {userId:String} AND mode = {mode:String} AND project_id = {projectId:String} AND reported_timestamp < {before:DateTime64(3, 'UTC')}";
 const WINDOW_QUERY =
-  "SELECT sum(debit_amount) as total FROM basic_usage_events WHERE user_id = {userId:String} AND mode = {mode:String} AND reported_timestamp > {lastBilled:DateTime64(3, 'UTC')} AND reported_timestamp < {before:DateTime64(3, 'UTC')}";
+  "SELECT sum(debit_amount) as total FROM basic_usage_events WHERE user_id = {userId:String} AND mode = {mode:String} AND project_id = {projectId:String} AND reported_timestamp > {lastBilled:DateTime64(3, 'UTC')} AND reported_timestamp < {before:DateTime64(3, 'UTC')}";
 
 export async function handlePriceRequestBasicUsage(
   userId: UserId,

--- a/src/storage/adapter/clickhouse/schema.ts
+++ b/src/storage/adapter/clickhouse/schema.ts
@@ -1,6 +1,5 @@
 import { getClickHouseDB } from "../../db/clickhouse";
 import { logger } from "../../../errors/logger";
-import { innerProduct } from "drizzle-orm";
 
 const BASIC_USAGE_EVENTS_TABLE = `
 CREATE TABLE IF NOT EXISTS basic_usage_events (
@@ -9,6 +8,7 @@ CREATE TABLE IF NOT EXISTS basic_usage_events (
   idempotency_key String,
   user_id String,
   api_key_id Nullable(String),
+  project_id String,
   mode String,
   reported_timestamp DateTime64(3, 'UTC'),
   ingested_timestamp DateTime64(3, 'UTC') DEFAULT now64(3, 'UTC'),
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS basic_usage_events (
   debit_amount Int64,
   metadata JSON
 ) ENGINE = ReplacingMergeTree()
-ORDER BY (idempotency_key, user_id)
+ORDER BY (project_id, idempotency_key, user_id)
 `;
 
 const AI_TOKEN_USAGE_EVENTS_TABLE = `
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS ai_token_usage_events (
   idempotency_key String,
   user_id String,
   api_key_id Nullable(String),
+  project_id String,
   mode String,
   reported_timestamp DateTime64(3, 'UTC'),
   ingested_timestamp DateTime64(3, 'UTC') DEFAULT now64(3, 'UTC'),
@@ -34,7 +35,15 @@ CREATE TABLE IF NOT EXISTS ai_token_usage_events (
   metrics String,
   metadata JSON
 ) ENGINE = ReplacingMergeTree()
-ORDER BY (idempotency_key, user_id)
+ORDER BY (project_id, idempotency_key, user_id)
+`;
+
+const ADD_PROJECT_ID_BASIC = `
+ALTER TABLE basic_usage_events ADD COLUMN IF NOT EXISTS project_id String DEFAULT ''
+`;
+
+const ADD_PROJECT_ID_AI_TOKEN = `
+ALTER TABLE ai_token_usage_events ADD COLUMN IF NOT EXISTS project_id String DEFAULT ''
 `;
 
 export async function runClickHouseMigrations(): Promise<void> {
@@ -45,4 +54,12 @@ export async function runClickHouseMigrations(): Promise<void> {
 
   await client.command({ query: AI_TOKEN_USAGE_EVENTS_TABLE });
   logger.lifecycle("ClickHouse: ai_token_usage_events table ensured");
+
+  await client.command({ query: ADD_PROJECT_ID_BASIC });
+  logger.lifecycle("ClickHouse: basic_usage_events project_id column ensured");
+
+  await client.command({ query: ADD_PROJECT_ID_AI_TOKEN });
+  logger.lifecycle(
+    "ClickHouse: ai_token_usage_events project_id column ensured"
+  );
 }

--- a/src/storage/adapter/clickhouse/utils.ts
+++ b/src/storage/adapter/clickhouse/utils.ts
@@ -71,6 +71,7 @@ export async function runClickHousePriceQuery(
     }
 
     params.mode = auth.mode;
+    params.projectId = auth.projectId;
 
     const rs = await chClient.query({
       query,

--- a/src/storage/adapter/postgres/handlers/addAiTokenUsage.ts
+++ b/src/storage/adapter/postgres/handlers/addAiTokenUsage.ts
@@ -123,6 +123,7 @@ function buildAiTokenInsertValues(
     ingestedTimestamp: DateTime.utc().toString(),
     userId: aggEvent.userId,
     apiKeyId: auth.apiKeyId,
+    projectId: auth.projectId,
     mode: auth.mode as "production" | "test",
     model: aggEvent.model,
     provider: aggEvent.provider,

--- a/src/storage/adapter/postgres/handlers/addBasicUsage.ts
+++ b/src/storage/adapter/postgres/handlers/addBasicUsage.ts
@@ -44,6 +44,7 @@ export async function handleAddBasicUsage(
             ingestedTimestamp: DateTime.utc().toString(),
             userId: event_data.userId,
             apiKeyId: auth.apiKeyId,
+            projectId: auth.projectId,
             mode: auth.mode as "production" | "test",
             type: event_data.data.basicUsageType,
             debitAmount: event_data.data.debitAmount,

--- a/src/storage/adapter/postgres/handlers/priceRequest.ts
+++ b/src/storage/adapter/postgres/handlers/priceRequest.ts
@@ -37,7 +37,7 @@ export async function handlePriceRequest(
 
     let result;
     try {
-      const baseCondition = sql`${priceTable.reportedTimestamp} > ${usersTable.last_billed_timestamp} AND ${priceTable.userId} = ${userId} AND ${priceTable.mode} = ${auth.mode}`;
+      const baseCondition = sql`${priceTable.reportedTimestamp} > ${usersTable.last_billed_timestamp} AND ${priceTable.userId} = ${userId} AND ${priceTable.mode} = ${auth.mode} AND ${priceTable.projectId} = ${auth.projectId}`;
       const whereClause = beforeTimestamp
         ? and(
             baseCondition,

--- a/src/storage/db/postgres/helpers/metadata.ts
+++ b/src/storage/db/postgres/helpers/metadata.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { executeInTransaction } from "../../../adapter/postgres/handlers/addEventUtils";
 
 export type UpsertMetadataInput = {
+  projectId: string;
   dodo_live_api_key?: string;
   dodo_test_api_key?: string;
   dodo_live_product_id?: string;
@@ -25,6 +26,7 @@ export async function upsertMetadata(
       const [existingMetadata] = await txn
         .select({ id: metadataTable.id })
         .from(metadataTable)
+        .where(eq(metadataTable.projectId, input.projectId))
         .limit(1)
         .for("update");
 
@@ -56,6 +58,7 @@ export async function upsertMetadata(
       }
 
       const insertValues: typeof metadataTable.$inferInsert = {
+        projectId: input.projectId,
         ...setValues,
       } as typeof metadataTable.$inferInsert;
       await txn.insert(metadataTable).values(insertValues);
@@ -68,10 +71,14 @@ export async function upsertMetadata(
   });
 }
 
-export async function getMetadata(): Promise<
-  typeof metadataTable.$inferSelect | undefined
-> {
+export async function getMetadata(
+  projectId: string
+): Promise<typeof metadataTable.$inferSelect | undefined> {
   const db = getPostgresDB();
-  const [metadata] = await db.select().from(metadataTable).limit(1);
+  const [metadata] = await db
+    .select()
+    .from(metadataTable)
+    .where(eq(metadataTable.projectId, projectId))
+    .limit(1);
   return metadata;
 }

--- a/src/storage/db/postgres/helpers/payments.ts
+++ b/src/storage/db/postgres/helpers/payments.ts
@@ -10,6 +10,7 @@ export async function handleAddPayment(
   apiKeyId: string,
   mode: "test" | "production",
   proxyId: string,
+  projectId: string,
   txn?: PgTransaction<any, any, any>
 ): Promise<{ id: string }> {
   if (
@@ -36,6 +37,7 @@ export async function handleAddPayment(
         mode,
         creditAmount,
         proxyId,
+        projectId,
       })
       .returning({ id: paymentEventsTable.id });
 

--- a/src/storage/db/postgres/helpers/projects.ts
+++ b/src/storage/db/postgres/helpers/projects.ts
@@ -1,0 +1,69 @@
+import { getPostgresDB } from "../db";
+import { projectsTable } from "../schema";
+import { eq } from "drizzle-orm";
+import { StorageError } from "../../../../errors/storage";
+
+export async function createProject(name: string): Promise<{ id: string }> {
+  const db = getPostgresDB();
+
+  try {
+    const [result] = await db
+      .insert(projectsTable)
+      .values({ name })
+      .returning({ id: projectsTable.id });
+
+    if (!result) {
+      throw StorageError.emptyResult("Project insert returned no ID");
+    }
+
+    return { id: result.id };
+  } catch (e) {
+    if (
+      e &&
+      typeof e === "object" &&
+      "name" in e &&
+      (e as Error).name === "StorageError"
+    ) {
+      throw e;
+    }
+    throw StorageError.insertFailed(
+      "Failed to create project",
+      e instanceof Error ? e : new Error(String(e))
+    );
+  }
+}
+
+export async function listProjects(): Promise<
+  (typeof projectsTable.$inferSelect)[]
+> {
+  const db = getPostgresDB();
+  return db.select().from(projectsTable).orderBy(projectsTable.createdAt);
+}
+
+export async function deleteProject(projectId: string): Promise<boolean> {
+  const db = getPostgresDB();
+
+  try {
+    const result = await db
+      .delete(projectsTable)
+      .where(eq(projectsTable.id, projectId));
+    return (result.count ?? 0) > 0;
+  } catch (e) {
+    throw StorageError.queryFailed(
+      "Failed to delete project",
+      e instanceof Error ? e : new Error(String(e))
+    );
+  }
+}
+
+export async function getProject(
+  projectId: string
+): Promise<typeof projectsTable.$inferSelect | undefined> {
+  const db = getPostgresDB();
+  const [row] = await db
+    .select()
+    .from(projectsTable)
+    .where(eq(projectsTable.id, projectId))
+    .limit(1);
+  return row;
+}

--- a/src/storage/db/postgres/helpers/sessions.ts
+++ b/src/storage/db/postgres/helpers/sessions.ts
@@ -33,7 +33,8 @@ export async function updateSessionStatus(
 export async function checkIfExistingCheckoutLink(
   txn: PgTransaction<any, any, any>,
   userId: UserId,
-  mode: "test" | "production"
+  mode: "test" | "production",
+  projectId: string
 ): Promise<string | undefined> {
   try {
     if (!txn) {
@@ -48,6 +49,7 @@ export async function checkIfExistingCheckoutLink(
           eq(sessionsTable.userId, userId),
           eq(sessionsTable.processed, "pending"),
           eq(sessionsTable.mode, mode),
+          eq(sessionsTable.projectId, projectId),
           sql`${sessionsTable.createdAt} > ${DateTime.utc().minus({ hours: 24 }).toISO()}`
         )
       )
@@ -74,6 +76,7 @@ export async function handleAddSession(
   apiKeyId: string,
   mode: "test" | "production",
   checkoutUrl: string,
+  projectId: string,
   txn?: PgTransaction<any, any, any>
 ): Promise<{ id: string }> {
   const connectionObject = txn ?? getPostgresDB();
@@ -97,6 +100,7 @@ export async function handleAddSession(
         apiKeyId: apiKeyId,
         mode: mode,
         checkoutUrl: checkoutUrl,
+        projectId: projectId,
       })
       .returning({ proxy_link_id: sessionsTable.proxy_link_id });
 

--- a/src/storage/db/postgres/schema.ts
+++ b/src/storage/db/postgres/schema.ts
@@ -14,6 +14,25 @@ import { USER_ID_CONFIG } from "../../../config/identifiers";
 import { DateTime } from "luxon";
 import { type Metrics } from "../../../zod/metrics";
 
+export const projectsTable = pgTable("projects", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  name: text("name").notNull(),
+  createdAt: timestamp("created_at", {
+    withTimezone: true,
+    mode: "string",
+  })
+    .defaultNow()
+    .notNull(),
+});
+
+export const projectsRelation = relations(projectsTable, ({ many }) => ({
+  sessions: many(sessionsTable),
+  basicUsageEvents: many(basicUsageEventsTable),
+  aiTokenUsageEvents: many(aiTokenUsageEventsTable),
+  paymentEvents: many(paymentEventsTable),
+  metadata: many(metadataTable),
+}));
+
 export const usersTable = pgTable("users", {
   id: USER_ID_CONFIG.dbType("id").primaryKey(),
   last_billed_timestamp: timestamp("last_billed_timestamp", {
@@ -49,6 +68,9 @@ export const sessionsTable = pgTable(
     apiKeyId: uuid("api_key_id")
       .references(() => apiKeysTable.id)
       .notNull(),
+    projectId: uuid("project_id")
+      .references(() => projectsTable.id)
+      .notNull(),
     billed_upto: timestamp("billed_upto", {
       withTimezone: true,
       mode: "string",
@@ -77,6 +99,10 @@ export const sessionRelations = relations(sessionsTable, ({ one, many }) => ({
   apiKey: one(apiKeysTable, {
     fields: [sessionsTable.apiKeyId],
     references: [apiKeysTable.id],
+  }),
+  project: one(projectsTable, {
+    fields: [sessionsTable.projectId],
+    references: [projectsTable.id],
   }),
   paymentEvents: many(paymentEventsTable),
 }));
@@ -140,6 +166,9 @@ export const basicUsageEventsTable = pgTable("basic_usage_events", {
   apiKeyId: uuid("api_key_id")
     .references(() => apiKeysTable.id)
     .notNull(),
+  projectId: uuid("project_id")
+    .references(() => projectsTable.id)
+    .notNull(),
   mode: text("mode", { enum: ["test", "production"] }).notNull(),
   type: text("type", { enum: ["RAW", "MIDDLEWARE_CALL"] }).notNull(),
   debitAmount: bigint("debit_amount", { mode: "number" }).notNull(),
@@ -156,6 +185,10 @@ export const basicUsageEventsRelation = relations(
     apiKey: one(apiKeysTable, {
       fields: [basicUsageEventsTable.apiKeyId],
       references: [apiKeysTable.id],
+    }),
+    project: one(projectsTable, {
+      fields: [basicUsageEventsTable.projectId],
+      references: [projectsTable.id],
     }),
   })
 );
@@ -178,6 +211,9 @@ export const paymentEventsTable = pgTable("payment_events", {
   apiKeyId: uuid("api_key_id")
     .references(() => apiKeysTable.id)
     .notNull(),
+  projectId: uuid("project_id")
+    .references(() => projectsTable.id)
+    .notNull(),
   mode: text("mode", { enum: ["test", "production"] }).notNull(),
   creditAmount: bigint("credit_amount", { mode: "number" }).notNull(),
   proxyId: uuid("proxy_id")
@@ -195,6 +231,10 @@ export const paymentEventsRelation = relations(
     apiKey: one(apiKeysTable, {
       fields: [paymentEventsTable.apiKeyId],
       references: [apiKeysTable.id],
+    }),
+    project: one(projectsTable, {
+      fields: [paymentEventsTable.projectId],
+      references: [projectsTable.id],
     }),
     session: one(sessionsTable, {
       fields: [paymentEventsTable.proxyId],
@@ -223,6 +263,9 @@ export const aiTokenUsageEventsTable = pgTable("ai_token_usage_events", {
   apiKeyId: uuid("api_key_id")
     .references(() => apiKeysTable.id)
     .notNull(),
+  projectId: uuid("project_id")
+    .references(() => projectsTable.id)
+    .notNull(),
   mode: text("mode", { enum: ["test", "production"] }).notNull(),
   model: text("model").notNull(),
   provider: text("provider").notNull(),
@@ -241,6 +284,10 @@ export const aiTokenUsageEventsRelation = relations(
       fields: [aiTokenUsageEventsTable.apiKeyId],
       references: [apiKeysTable.id],
     }),
+    project: one(projectsTable, {
+      fields: [aiTokenUsageEventsTable.projectId],
+      references: [projectsTable.id],
+    }),
   })
 );
 
@@ -254,21 +301,37 @@ export const tagsTable = pgTable("tags", {
   }),
 });
 
-export const metadataTable = pgTable("metadata", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  last_run_at: timestamp("last_run_at", {
-    withTimezone: true,
-    mode: "string",
+export const metadataTable = pgTable(
+  "metadata",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    projectId: uuid("project_id")
+      .references(() => projectsTable.id)
+      .notNull(),
+    last_run_at: timestamp("last_run_at", {
+      withTimezone: true,
+      mode: "string",
+    }),
+    dodo_live_api_key: text("dodo_live_api_key").notNull(),
+    dodo_test_api_key: text("dodo_test_api_key").notNull(),
+    dodo_live_product_id: text("dodo_live_product_id").notNull(),
+    dodo_test_product_id: text("dodo_test_product_id").notNull(),
+    dodo_live_webhook_secret: text("dodo_live_webhook_secret").notNull(),
+    dodo_test_webhook_secret: text("dodo_test_webhook_secret").notNull(),
+    currency: text("currency").notNull().default("usd"),
+    redirect_url: text("redirect_url").notNull(),
+  },
+  (table) => ({
+    uniqueProject: uniqueIndex("unique_metadata_project").on(table.projectId),
+  })
+);
+
+export const metadataRelation = relations(metadataTable, ({ one }) => ({
+  project: one(projectsTable, {
+    fields: [metadataTable.projectId],
+    references: [projectsTable.id],
   }),
-  dodo_live_api_key: text("dodo_live_api_key").notNull(),
-  dodo_test_api_key: text("dodo_test_api_key").notNull(),
-  dodo_live_product_id: text("dodo_live_product_id").notNull(),
-  dodo_test_product_id: text("dodo_test_product_id").notNull(),
-  dodo_live_webhook_secret: text("dodo_live_webhook_secret").notNull(),
-  dodo_test_webhook_secret: text("dodo_test_webhook_secret").notNull(),
-  currency: text("currency").notNull().default("usd"),
-  redirect_url: text("redirect_url").notNull(),
-});
+}));
 
 export const expressionsTable = pgTable("expressions", {
   id: uuid("id").primaryKey().defaultRandom(),

--- a/src/utils/authenticateHttpApiKey.ts
+++ b/src/utils/authenticateHttpApiKey.ts
@@ -44,7 +44,12 @@ export async function authenticateHttpApiKey(
         `Key prefix ${role} doesn't match stored role ${cached.role}`
       );
     }
-    return { apiKeyId: cached.id, role: cached.role, mode: cached.mode };
+    return {
+      apiKeyId: cached.id,
+      role: cached.role,
+      mode: cached.mode,
+      projectId: "",
+    };
   }
 
   const apiKeyRecord = await findApiKeyByHash(apiKeyHash);
@@ -79,5 +84,5 @@ export async function authenticateHttpApiKey(
     expiresAt: apiKeyRecord.expiresAt,
   });
 
-  return { apiKeyId: apiKeyRecord.id, role: recordRole, mode };
+  return { apiKeyId: apiKeyRecord.id, role: recordRole, mode, projectId: "" };
 }


### PR DESCRIPTION
This pull request introduces multi-project support to the authentication and payment systems. The major changes include requiring a `projectId` for all authenticated requests, scoping payment provider configuration and clients to individual projects, and refactoring onboarding to register projects and their associated payment/webhook credentials. These updates ensure that all API and payment operations are securely and correctly tied to a specific project.

**Authentication and Project Context**

- The `AuthContext` interface now includes a `projectId`, and the gRPC auth interceptor (`authInterceptor`) requires the `x-project-id` metadata header, validating the existence of the project before proceeding. All authenticated requests are now project-scoped.

- A new cache (`projectExistsCache`) and helper (`checkProjectExists`) are added to efficiently verify project existence during authentication.

**Payment Provider Refactor for Multi-Project Support**

- Payment provider clients (`DodoPayments`) are now cached per project, and all payment operations require a `projectId`. The `getDodoClient`, `getPaymentProviderConfig`, and `createProviderCheckout` functions are updated to accept and use `projectId`.

- All payment-related routes and helpers, including `createCheckoutLink` and its dependencies, are updated to pass the `projectId` throughout the payment flow.

**Onboarding Refactor for Project Creation**

- The onboarding route is refactored to a `handleCreateProject` handler, which creates a new project, registers Dodo payment webhooks for the project, and stores encrypted credentials and configuration per project. The onboarding schema is updated and validated with Zod.

- Webhook URLs and descriptions are now project-specific, and errors are returned with more detail. Payment provider client caches are invalidated per project after onboarding updates. 

**Error Handling and Response Improvements**

- Error handling in onboarding is improved to return structured error responses with details for missing environment variables, webhook registration failures, and schema validation errors.